### PR TITLE
Add support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
 - "2.7"
+- "3.2"
+- "3.3"
+- "3.4"
 # command to install dependencies
 install:
 - "pip install ."

--- a/gospellibrary/__init__.py
+++ b/gospellibrary/__init__.py
@@ -1,6 +1,5 @@
 import requests
 import logging
-from StringIO import StringIO
 from zipfile import ZipFile
 from tempfile import mkdtemp
 import os
@@ -8,6 +7,14 @@ import sqlite3
 import shutil
 from contextlib import contextmanager
 from reprutils import GetattrRepr
+
+try:
+    from StringIO import StringIO
+    Bytes = StringIO
+except ImportError:
+    from io import BytesIO
+    Bytes = BytesIO
+
 
 DEFAULT_BASE_URL = 'http://broadcast3.lds.org/crowdsource/mobile/gospelstudy/production'
 SCHEMA_VERSION = '2.0.3'
@@ -55,7 +62,7 @@ class Catalog:
                 except OSError:
                     pass
 
-                with ZipFile(StringIO(r.content), 'r') as catalog_zip_file:
+                with ZipFile(Bytes(r.content), 'r') as catalog_zip_file:
                     catalog_zip_file.extractall(os.path.dirname(catalog_path))
 
                 with sqlite3.connect(catalog_path) as db:
@@ -96,7 +103,7 @@ class Catalog:
                 except OSError:
                     pass
 
-                with ZipFile(StringIO(r.content), 'r') as catalog_zip_file:
+                with ZipFile(Bytes(r.content), 'r') as catalog_zip_file:
                     catalog_zip_file.extractall(os.path.dirname(catalog_path))
 
                 items = []
@@ -150,7 +157,7 @@ class Item:
             except OSError:
                 pass
 
-            with ZipFile(StringIO(r.content), 'r') as catalog_zip_file:
+            with ZipFile(Bytes(r.content), 'r') as catalog_zip_file:
                 catalog_zip_file.extractall(os.path.dirname(item_package_path))
 
             package = ItemPackage(path=item_package_path)

--- a/gospellibrary/__init__.py
+++ b/gospellibrary/__init__.py
@@ -4,7 +4,7 @@ from StringIO import StringIO
 from zipfile import ZipFile
 from tempfile import mkdtemp
 import os
-from pysqlite2 import dbapi2 as sqlite3
+import sqlite3
 import shutil
 from contextlib import contextmanager
 from reprutils import GetattrRepr

--- a/gospellibrary/tests/test_catalog.py
+++ b/gospellibrary/tests/test_catalog.py
@@ -23,9 +23,9 @@ class Test(unittest.TestCase):
 
     def test_items(self):
         items = Catalog(session=session).items()
-        self.assertTrue((u'/scriptures/bofm', u'eng') in items)
-        self.assertTrue((u'/general-conference/2014/10', u'eng') in items)
-        self.assertTrue((u'/general-conference/2014/10', u'spa') in items)
+        self.assertTrue(('/scriptures/bofm', 'eng') in items)
+        self.assertTrue(('/general-conference/2014/10', 'eng') in items)
+        self.assertTrue(('/general-conference/2014/10', 'spa') in items)
 
     def test_package_html(self):
         with Catalog(session=session).item(uri='/scriptures/bofm', lang='eng').package() as package:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ beautifulsoup4==4.3.2
 lockfile==0.10.2
 nose==1.3.4
 requests==2.4.3
-wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ CacheControl==0.10.4
 beautifulsoup4==4.3.2
 lockfile==0.10.2
 nose==1.3.4
-pysqlite==2.6.3
 requests==2.4.3
 wsgiref==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     long_description=open('README.md').read(),
     install_requires=[
         'requests==2.4.3',
-        'pysqlite==2.6.3',
         'reprutils==1.0',
     ],
 )


### PR DESCRIPTION
Some of the libraries that are used in python-gospel-library do not support Python 3. I changed these libraries so everything works with Python 2 and Python 3.